### PR TITLE
Enable ruseChunkedEncodingByDefault always

### DIFF
--- a/lib/api_request.js
+++ b/lib/api_request.js
@@ -69,6 +69,8 @@ class ApiRequest {
       });
     });
 
+    req.useChunkedEncodingByDefault = true;
+
     req.setTimeout(20 * 1000, function() {
       callback(new Error('request sending timeout'));
     });


### PR DESCRIPTION
In my code, `useChunkedEncodingByDefault` is always false for all requests by some reasons like this.
```javascript
const patch = function(mod) {
  const req = mod.request;
  mod.request = function(opts, callback) {
    const r = req(opts, callback);
    r.useChunkedEncodingByDefault = false;
    return r;
  }
};

const https = require('https');
patch(https);
...
```

At present stackimpact seems not working with `useChunkedEncodingByDefault = false`.
So it's better to set as true in this module.